### PR TITLE
Added additional fields needed for ack request

### DIFF
--- a/mms/encoder.go
+++ b/mms/encoder.go
@@ -73,8 +73,12 @@ func (enc *Encoder) Encode(pdu Writer) error {
 			err = enc.writeByteParam(HeaderXMmsMessageType, byte(f.Uint()))
 		case "Version":
 			err = enc.writeByteParam(HeaderXMmsMmsVersion, byte(f.Uint()))
+		case "ResponseStatus":
+			err = enc.writeByteParam(HeaderXMmsMmsVersion, byte(f.Uint()))
 		case "TransactionID":
 			err = enc.writeStringParam(HeaderXMmsTransactionID, f.String())
+		case "MessageID":
+			err = enc.writeStringParam(HeaderMessageID, f.String())
 		case "Status":
 			err = enc.writeByteParam(HeaderXMmsStatus, byte(f.Uint()))
 		case "From":

--- a/mms/mms.go
+++ b/mms/mms.go
@@ -215,7 +215,7 @@ type MSendConf struct {
 	TransactionID  string
 	Version        byte
 	ResponseStatus byte
-	ResponseText   string
+	ResponseText   string `encode:"optional"`
 	MessageID      string
 }
 


### PR DESCRIPTION
http://www.openmobilealliance.org/release/MMS/V1_3-20050927-C/OMA-TS-MMS-CONF-V1_3-20050927-C.pdf  shows that response text is optional, as well as the encoder was not encoding two necessary fields for mSendConf